### PR TITLE
Add packet encoding options

### DIFF
--- a/lib/communicator.ex
+++ b/lib/communicator.ex
@@ -7,7 +7,7 @@ defmodule LoRa.Communicator do
 
   def print(text, spi) do
     current_length = read_register(spi, Parameters.register().payload_length)
-    bytelist = text |> String.to_charlist()
+    bytelist = text |> :erlang.binary_to_list()
 
     if current_length + length(bytelist) < Parameters.max().pkt_length,
       do: write(spi, bytelist, length(bytelist)),

--- a/lib/encoding.ex
+++ b/lib/encoding.ex
@@ -1,0 +1,32 @@
+defmodule LoRa.Encoding do
+  @moduledoc """
+  Handles the encoding of Elxir terms to binary packets, and the decoding of
+  binary packet back into Elixir terms.
+
+  ## Encodings
+
+    - `:inspect` - encodes using `Kernel.inspect/2`, decodes to a string of that inspected value
+    - `:binary` - encodes and decodes raw binaries, directly
+    - `:term` - encodes and decodes terms using Erlang's [external term format](https://www.erlang.org/doc/apps/erts/erl_ext_dist.html)
+  """
+
+  @type encoding :: :inspect | :binary | :term
+
+  @doc """
+  Encodes a term as a binary for transmission of a packet.
+  """
+  @spec encode_data!(data :: term(), encoding :: encoding()) :: binary() | no_return()
+  def encode_data!(data, :inspect), do: inspect(data)
+  def encode_data!(data, :binary) when is_binary(data), do: data
+  def encode_data!(data, :term), do: :erlang.term_to_binary(data)
+  def encode_data!(_, _), do: raise(ArgumentError)
+
+  @doc """
+  Decodes a binary as a term upon reception of a packet.
+  """
+  @spec decode_data!(data :: binary(), encoding :: encoding()) :: term() | no_return()
+  def decode_data!(data, :inspect) when is_binary(data), do: data
+  def decode_data!(data, :binary) when is_binary(data), do: data
+  def decode_data!(data, :term) when is_binary(data), do: :erlang.binary_to_term(data)
+  def decode_data!(_, _), do: raise(ArgumentError)
+end

--- a/lib/lora.ex
+++ b/lib/lora.ex
@@ -1,7 +1,7 @@
 defmodule LoRa do
   @moduledoc """
   This is a module for transmitter data using LoRa Radios.
-  
+
   Radios:
       Semtech SX1276/77/78/79 based boards.
   """
@@ -13,6 +13,7 @@ defmodule LoRa do
 
   alias LoRa.Modem
   alias LoRa.Communicator
+  alias LoRa.Encoding
 
   require Logger
 
@@ -20,36 +21,41 @@ defmodule LoRa do
   @lora_default_spi "spidev0.0"
   @lora_default_spi_frequency 8_000_000
   @lora_default_reset_pin 25
+  @lora_default_encoding :inspect
   # @lora_default_dio0_pin 22
-  
+
   @doc """
   Start and link a new GenServer for LoRa radio.
 
   Can be set the parameters of SPI and GPIO pin for the reset of radio.
-  
+
     # standard values: `spi: "spidev0.0", spi_speed: 8_000_000, rst: 25`
       {:ok, lora} = LoRa.start_link()
     or
       {:ok, lora} = LoRa.start_link([spi: "spidev0.1", spi_speed: 5_000_000, rst: 27])
-  
+
   """
   def start_link(config \\ []), do: GenServer.start_link(__MODULE__, config ++ [owner: self()])
+
   @doc """
   Initialize the LoRa Radio and set your frequency work.
       {:ok, lora} = LoRa.start_link()
       LoRa.begin(lora, 433.0e6)
   """
   def begin(pid, frequency), do: GenServer.call(pid, {:begin, frequency})
+
   @doc """
-  Set the LoRa Radio in sleep mode. 
+  Set the LoRa Radio in sleep mode.
       LoRa.sleep(lora_pid)
   """
   def sleep(pid), do: GenServer.cast(pid, :sleep)
+
   @doc """
   Awake the LoRa Radio.
       LoRa.awake(lora_pid)
   """
   def awake(pid), do: GenServer.cast(pid, :awake)
+
   @doc """
   Set Spreading Factor. `sf` is a value between 6 and 12. Standar value is 6.
 
@@ -57,24 +63,28 @@ defmodule LoRa do
   """
   def set_spreading_factor(pid, sf \\ 6) when sf >= 6 and sf <= 12,
     do: GenServer.cast(pid, {:set_sf, sf})
+
   @doc """
   Set Trasmission Signal Bandwidth.
 
       LoRa.set_signal_bandwidth(lora_pid, 31.25e3)
   """
   def set_signal_bandwidth(pid, sbw), do: GenServer.cast(pid, {:set_sbw, sbw})
+
   @doc """
   This is a verify digit add in the data message.
 
       LoRa.enable_crc(lora_pid)
   """
   def enable_crc(pid), do: GenServer.cast(pid, :enable_crc)
+
   @doc """
   Remove the verify digit.
 
       LoRa.disable_crc(lora_pid)
   """
   def disable_crc(pid), do: GenServer.cast(pid, :disable_crc)
+
   @doc """
   Send data for other radios.
 
@@ -91,10 +101,18 @@ defmodule LoRa do
     pin_reset = Keyword.get(config, :rst, @lora_default_reset_pin)
     device = Keyword.get(config, :spi, @lora_default_spi)
     speed_hz = Keyword.get(config, :spi_speed, @lora_default_spi_frequency)
+    encoding = Keyword.get(config, :encoding, @lora_default_encoding)
 
     {:ok, spi} = start_spi(device, speed_hz)
 
-    state = %{is_receiver?: true, owner: config[:owner], spi: nil, rst: nil, config: nil}
+    state = %{
+      is_receiver?: true,
+      owner: config[:owner],
+      encoding: encoding,
+      spi: nil,
+      rst: nil,
+      config: nil
+    }
 
     Logger.info("LoRa: Start Device")
     {:ok, rst} = GPIO.start_link(pin_reset, :output)
@@ -120,7 +138,7 @@ defmodule LoRa do
 
   def handle_info({:receive_msg, pkt_length}, state) do
     Logger.debug("LoRa: message recieved: #{pkt_length}Bytes")
-    Modem.read(state.config.frequency, state.owner, state.spi)
+    Modem.read(state.config.frequency, state.owner, state.spi, state.encoding)
     {:noreply, state}
   end
 
@@ -166,9 +184,11 @@ defmodule LoRa do
     Kernel.send(self(), :receiver_mode)
     Modem.idle(state.spi)
     GenServer.cast(__MODULE__, {:header_mode, header})
+
     data
-    |> Kernel.inspect()
+    |> Encoding.encode_data!(state.encoding)
     |> Communicator.print(state.spi)
+
     self() |> Modem.end_packet(state.spi)
 
     {:noreply, %{state | is_receiver?: true}}

--- a/lib/modem.ex
+++ b/lib/modem.ex
@@ -6,6 +6,7 @@ defmodule LoRa.Modem do
 
   alias LoRa.Communicator
   alias LoRa.Parameters
+  alias LoRa.Encoding
 
   # def transmitting?(spi) do
   #   irq_flags = Communicator.read_register(spi, Parameters.register.irq_flags)
@@ -80,18 +81,18 @@ defmodule LoRa.Modem do
     )
   end
 
-  def read(frequency, owner, spi, index \\ 0, msg \\ []) do
+  def read(frequency, owner, spi, encoding, index \\ 0, msg \\ []) do
     r_byte = Communicator.read_register(spi, Parameters.register().fifo)
     nb_bytes = Communicator.read_register(spi, Parameters.register().rx_nb_bytes) - 1
 
     if nb_bytes - index + 1 > 0,
-      do: read(frequency, owner, spi, index + 1, msg ++ [r_byte]),
+      do: read(frequency, owner, spi, encoding, index + 1, msg ++ [r_byte]),
       else:
         Kernel.send(
           owner,
           {:lora,
            %{
-             packet: List.to_string(msg),
+             packet: msg |> :erlang.list_to_binary() |> Encoding.decode_data!(encoding),
              rssi: rssi(frequency, spi),
              snr: snr(spi),
              time: DateTime.now!("Etc/UTC")

--- a/lib/modem.ex
+++ b/lib/modem.ex
@@ -45,7 +45,7 @@ defmodule LoRa.Modem do
       pid = spawn_link(__MODULE__, :verify_end_packet, [spi, from])
       ref = Process.monitor(pid)
 
-      Task.yield(%Task{pid: pid, ref: ref, owner: from}, 2000)
+      Task.yield(%Task{pid: pid, ref: ref, owner: from, mfa: nil}, 2000)
     end
   end
 

--- a/lib/parameters.ex
+++ b/lib/parameters.ex
@@ -76,7 +76,7 @@ defmodule LoRa.Parameters do
     6 => 62.5e3,
     7 => 125.0e3,
     8 => 250.0e3,
-    9 => 250.0e3
+    9 => 500.0e3
   }
 
   def register, do: @reg


### PR DESCRIPTION
Currently, when sending a packet of data, it is simply `inspect`ed and sent along its way. This is not a particularly useful representation of data when trying to decode it on the other end.

This PR adds an `:encoding` option to the `LoRa` GenServer, which can specify how packet data is encoded (before transmission) and decoded (after reception). This is handled by the new `LoRa.Encoding` module.

The options are:

- `:inspect` (default, for backwards compatibility) - encodes using `Kernel.inspect/2`, decodes to a string of that inspected value
- `:binary` - encodes and decodes raw binaries, directly
- `:term` - encodes and decodes terms using Erlang's [external term format](https://www.erlang.org/doc/apps/erts/erl_ext_dist.html)

There's no error handling if an invalid value is passed in; the process will crash. I figured that's good enough for a first pass.

## What else changed?
* `mix format` on one file
* Fix typo, which adds 500 kHz bandwidth support (confirmed on the SX127x datasheet)